### PR TITLE
Added an option to order results by folders, files, or let them have no order

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -48,6 +48,18 @@
       "name": "Max results to be shown",
       "description": "Sets how many results should be shown.",
       "default_value": "20"
+    },
+    {
+      "id": "results_order",
+      "type": "select",
+      "name": "Order of Results",
+      "description": "Sets the order in which results are displayed.",
+      "default_value": "Folders First",
+      "options": [
+        "Folders First",
+        "Files First",
+        "No Order"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Best file search extension by far.  However when I want to search on my computer I normally want to search for folders and it was annoying having to go down to wherever the folder was put in the results. So I added some options to chose how you want the results to be ordered. 

Options:
![image](https://github.com/user-attachments/assets/f724a82d-1b65-4064-b9cb-45f12f341f1c)

Folders First: 
![image](https://github.com/user-attachments/assets/5180abc4-f7bd-4353-bd2a-74dde9756e23)

Files First:
![image](https://github.com/user-attachments/assets/dd091a7f-9825-4d9c-9323-955ca88f5bac)

No Order:
![image](https://github.com/user-attachments/assets/0eb4ebe6-5031-4b72-8fe1-6ace3304341b)


